### PR TITLE
Update UPGRADING.md guide for removing other sprocket-dependent Gems

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -206,10 +206,11 @@ Start by following these steps:
 
 1. Remove `sprockets`, `sprockets-rails`, and `sass-rails` from the Gemfile and add `propshaft`;
 2. Run `./bin/bundle install`;
-3. Open `config/application.rb` and remove `config.assets.paths << Rails.root.join('app','assets')`;
-4. Remove `app/assets/config/manifest.js`.
-5. Replace all asset_helpers (`image_url`, `font_url`) in css files with standard `urls`.
-6. If you are importing only the frameworks you need (instead of `rails/all`), remove `require "sprockets/railtie"`;
+3. Check your `Gemfile.lock` and repeat steps 1.+2. for any remaining Gems that list `sprockets` or `sprockets-rails` as a dependency;
+4. Open `config/application.rb` and remove `config.assets.paths << Rails.root.join('app','assets')`;
+5. Remove `app/assets/config/manifest.js`.
+6. Replace all asset_helpers (`image_url`, `font_url`) in css files with standard `urls`.
+7. If you are importing only the frameworks you need (instead of `rails/all`), remove `require "sprockets/railtie"`;
 
 ### Asset paths
 


### PR DESCRIPTION
**PR purpose**
This PR mentions that as part of Upgrading steps, you should also remove other gems that list sprockets as a dependency

**Background**
I was following the Upgrading guide for migrating from sprockets to propshaft, and I ran into a bit of trouble because I had a few other gems that were still using sprockets. So I wanted to add a step to the upgrading guide, that could have helped myself. I didnt know behind the scenes, the sprockets railtie was taking priority even when a dependency so heres what I ran into:

1. Followed the upgrade guide, then ran `rails assets:reveal` and saw this log, which made me think sprockets was still being initialized instead of propshaft
```
rails assets:reveal
** Invoke assets:reveal (first_time)
** Invoke assets:environment (first_time)
** Execute assets:environment
** Invoke environment (first_time)
** Execute environment
bin/rails aborted!
Sprockets::Railtie::ManifestNeededError: Expected to find a manifest file in `app/assets/config/manifest.js` (Sprockets::Railtie::ManifestNeededError)
But did not, please create this file and use it to link any assets that need
to be rendered by your app:

Example:
  //= link_tree ../images
  //= link_directory ../javascripts .js
  //= link_directory ../stylesheets .css
and restart your server

For more information see: https://github.com/rails/sprockets/blob/070fc01947c111d35bb4c836e9bb71962a8e0595/UPGRADING.md#manifestjs
```
3. My app's Gemfile had these gems still depending on sprockets
`gem "bootstrap", "~> 5.1.3"`
`gem "sassc-rails"`
4. I removed these Gems, ran `bundle install` and the `rails assets:reveal` worked, hello propshaft!
5. Ended up converting my application.scss to css since it wasnt too large

I thought about contributing some sort of solution like "Only load the propshaft railtie when this config boolean is true, and sprockets is in the rails app's Gemfile.lock", but it seems overkill, and would be hacky anyways https://stackoverflow.com/questions/49668286/disable-a-gems-railtie-initializer